### PR TITLE
fix(bin): support Node.js 22 on Windows by importing CLI via file:// URL

### DIFF
--- a/.yarn/versions/55e7024f.yml
+++ b/.yarn/versions/55e7024f.yml
@@ -1,0 +1,2 @@
+releases:
+  "@ngx-playwright/test": patch

--- a/packages/test/bin.cjs
+++ b/packages/test/bin.cjs
@@ -2,6 +2,7 @@
 
 const {readFileSync} = require("fs");
 const {dirname, resolve} = require("path");
+const {pathToFileURL} = require("url");
 
 const playwrightPkgJsonPath = require.resolve("@playwright/test/package.json");
 
@@ -18,4 +19,5 @@ if (typeof relativeBin !== "string") {
 	);
 }
 
-import(resolve(dirname(playwrightPkgJsonPath), relativeBin));
+const target = resolve(dirname(playwrightPkgJsonPath), relativeBin);
+import(pathToFileURL(target).href);


### PR DESCRIPTION
On Windows with Node.js 22.x, invoking the @ngx-playwright/test binary fails with:

Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]:
Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'


Root cause
packages/test/bin.cjs resolves the Playwright CLI to an absolute Windows path and passes it directly to import(). Since Node 22 treats ESM specifiers as URLs, C:\... is interpreted as the unsupported scheme c: and is rejected.

Fix
Convert the absolute path to a file:// URL using pathToFileURL(...) before calling import().

Compatibility:

-Works on Node 18/20/22
-Cross-platform (Windows/macOS/Linux)
-No breaking changes

How I tested:
Windows 11
Node.js 22.13.1 (repro), Node.js 20.17.0 (sanity)

npx playwright --version and running tests via the package binary

Notes:
An alternative would be using createRequire(import.meta.url) to require() the CLI, but the file:// approach keeps the current dynamic import() and fixes the ESM URL issue cleanly.

Thanks!